### PR TITLE
fix: Make iterable support less general.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlalchemy-model-factory"
-version = "0.4.3"
+version = "0.4.4"
 description = "A library to assist in generating models from a central location."
 authors = ["Dan Cardin <ddcardin@gmail.com>"]
 license = "Apache-2.0"

--- a/src/sqlalchemy_model_factory/base.py
+++ b/src/sqlalchemy_model_factory/base.py
@@ -1,7 +1,8 @@
-from collections.abc import Iterable
 from typing import Any, Dict, Optional, Set
 
 from sqlalchemy_model_factory.registry import Method, Registry
+
+_ITERABLES = (list, tuple, set)
 
 
 class Options:
@@ -54,7 +55,7 @@ class ModelFactory:
             self.session.begin()
 
         if merge:
-            if isinstance(result, Iterable):
+            if isinstance(result, _ITERABLES):
                 items = []
                 for item in result:
                     items.append(self.session.merge(item))
@@ -62,7 +63,7 @@ class ModelFactory:
             else:
                 result = self.session.merge(result)
         else:
-            if isinstance(result, Iterable):
+            if isinstance(result, _ITERABLES):
                 for item in result:
                     self.session.add(item)
             else:
@@ -79,7 +80,7 @@ class ModelFactory:
             else:
                 self.session.flush()
 
-            if isinstance(result, Iterable):
+            if isinstance(result, _ITERABLES):
                 for item in result:
                     self.session.refresh(item)
             else:


### PR DESCRIPTION
The `sqlservice` library makes models themselves iterable. Realistically, factories aren't producing custom collections as their results, if they produce more than one object at all, it should be a default built-in collection.